### PR TITLE
Centralizar lógica de acceso a datos en BrandRepository

### DIFF
--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -7,13 +7,16 @@ using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configuración de la aplicación
+// Configuraciï¿½n de la aplicaciï¿½n
 builder.Configuration.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
 
 //Repository
 
-builder.Services.AddScoped<IBeerRepository<Beer>,BeerRepository>();
+// Registra el repositorio de cervezas como implementacion de IBeerRepository
+builder.Services.AddScoped<IBeerRepository<Beer>, BeerRepository>();
 
+// Registra el repositorio de marcas como implementacion de IBrandRepository
+builder.Services.AddScoped<IBrandRepository<Brand>, BrandRepository>();
 
 // Agrega el contexto de la base de datos usando Entity Framework Core
 builder.Services.AddDbContext<StoreContext>(options =>
@@ -33,7 +36,7 @@ builder.Services.AddControllers();
 // Configura FluentValidation y registra el BeerInsertValidator como implementacion de IValidator<BeerInsertDto>
 builder.Services.AddScoped<IValidator<BeerInsertDto>, BeerInsertValidator>();
 
-// Configuración y registro del servicio de posts
+// Configuracion y registro del servicio de posts
 builder.Services.AddScoped<IPostsService, PostsService>();
 
 // Configura y agrega un cliente HTTP para el servicio de posts
@@ -59,11 +62,11 @@ if (app.Environment.IsDevelopment())
 // Configura el middleware para redireccionar a HTTPS
 app.UseHttpsRedirection();
 
-// Configura el middleware de autorización
+// Configura el middleware de autorizacion
 app.UseAuthorization();
 
-// Configura el middleware para mapear los controladores de la aplicación
+// Configura el middleware para mapear los controladores de la aplicacion
 app.MapControllers();
 
-// Ejecuta la aplicación
+// Ejecuta la aplicacion
 app.Run();

--- a/Backend/Repository/BrandRepository.cs
+++ b/Backend/Repository/BrandRepository.cs
@@ -1,0 +1,61 @@
+﻿using Backend.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Repository
+{
+    public class BrandRepository : IBrandRepository<Brand>
+    {
+        private readonly StoreContext _storeContext;
+
+        public BrandRepository(StoreContext storeContext)
+        {
+            _storeContext = storeContext;
+        }
+
+        // Agrega una nueva marca a la base de datos
+        public async Task<Brand> Add(Brand entity)
+        {
+            _storeContext.Brands.Add(entity);
+            await Save(); // Guarda los cambios en la base de datos
+            return entity;
+        }
+
+        // Obtiene todas las marcas de la base de datos
+        public async Task<IEnumerable<Brand>> GetAllBrands()
+        {
+            return await _storeContext.Brands.ToListAsync();
+        }
+
+        // Obtiene una marca por su ID
+        public async Task<Brand?> GetBrandById(int id)
+        {
+            return await _storeContext.Brands.FindAsync(id);
+        }
+
+        // Guarda los cambios en la base de datos
+        public async Task Save()
+        {
+            await _storeContext.SaveChangesAsync();
+        }
+
+        // Actualiza una marca existente por su ID
+        public async Task<IActionResult> Update(int id, Brand entity)
+        {
+            var existingBrand = await _storeContext.Brands.FindAsync(id);
+
+            if (existingBrand == null)
+            {
+                return new NotFoundResult(); // Retorna NotFound si la marca no existe
+            }
+
+            // Actualiza las propiedades según tus necesidades
+            existingBrand.Name = entity.Name;
+            existingBrand.Description = entity.Description;
+
+            await Save(); // Guarda los cambios en la base de datos
+
+            return new NoContentResult(); // Retorna NoContent indicando que la actualización fue exitosa
+        }
+    }
+}

--- a/Backend/Repository/IBrandRepository.cs
+++ b/Backend/Repository/IBrandRepository.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+
+namespace Backend.Repository
+{
+    public interface IBrandRepository<T>
+    {
+        Task<IEnumerable<T>> GetAllBrands();
+
+        Task<T?> GetBrandById(int id);
+
+        Task<T> Add(T entity);
+
+        Task<IActionResult> Update(int id, T entity);
+
+        Task Save();
+    }
+}


### PR DESCRIPTION
Se ha centralizado la lógica de acceso a datos de las operaciones CRUD de cervezas en BrandRepository, promoviendo una estructura más modular y mantenible. El servicio BrandService ahora delega las operaciones al repositorio.